### PR TITLE
Use font-display swap

### DIFF
--- a/styles/base/_typography.scss
+++ b/styles/base/_typography.scss
@@ -7,7 +7,7 @@
   src: url('/fonts/SpaceGrotesk-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 @font-face {
@@ -15,7 +15,7 @@
   src: url('/fonts/SpaceGrotesk-SemiBold.ttf') format('truetype');
   font-weight: 500;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 @font-face {
@@ -23,7 +23,7 @@
   src: url('/fonts/SpaceGrotesk-Bold.ttf') format('truetype');
   font-weight: 800;
   font-style: normal;
-  font-display: optional;
+  font-display: swap;
 }
 
 $fallback-stack: (
@@ -49,6 +49,7 @@ $emoji-stack: (
 body {
   font-size: 100%;
   font-family: 'Space Grotesk', $fallback-stack, $emoji-stack;
+  font-weight: 400;
   color: $txt-dark;
   background-color: $bg-light;
 }


### PR DESCRIPTION
Self-hosted font loads on live site only after CTRL+F5. Attempt to fix font loading by using `font-display: swap`.